### PR TITLE
Moved geojson to ambient dependency

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -10,7 +10,9 @@
     "node": "registry:dt/node#4.0.0+20160319033040"
   },
   "dependencies": {
-    "geojson": "registry:dt/geojson#0.0.0+20160319143602",
     "es6-promise": "registry:npm/es6-promise#3.0.0+20160211003958"
+  },
+  "ambientDependencies": {
+    "geojson": "registry:dt/geojson#0.0.0+20160319143602"
   }
 }


### PR DESCRIPTION
I used this `.d.ts` with typings, I got below errors:

```
213       geometry: GeoJSON.Point,
                    ~~~~~~~

typings/main/definitions/twit/index.d.ts(213,17): error TS2503: Cannot find namespace 'GeoJSON'.


215       bounding_box: GeoJSON.Polygon,
                        ~~~~~~~

typings/main/definitions/twit/index.d.ts(215,21): error TS2503: Cannot find namespace 'GeoJSON'.


232       coordinates?: GeoJSON.Point,
                        ~~~~~~~
...
```

`twit.d.ts` depends on `geojson.d.ts`, and it is put in DefinitelyTyped.  So I think `geojson.d.ts` should be added as ambient dependency to use.
