### PR TITLE
Removed implicit any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -249,22 +249,22 @@ declare class Twit {
   constructor( config: Twit.Options );
 
   // See https://github.com/ttezel/twit#tgetpath-params-callback
-  get( path: string, callback: Twit.Callback );
-  get( path: string, params: Twit.Params, callback: Twit.Callback );
+  get( path: string, callback: Twit.Callback ): void;
+  get( path: string, params: Twit.Params, callback: Twit.Callback ): void;
   get( path: string, params?: Twit.Params ): Promise<Twit.PromiseResponse>;
 
   // See https://github.com/ttezel/twit#tpostpath-params-callback
-  post( path: string, callback: Twit.Callback );
-  post( path: string, params: Twit.Params, callback: Twit.Callback );
+  post( path: string, callback: Twit.Callback ): void;
+  post( path: string, params: Twit.Params, callback: Twit.Callback ): void;
   post( path: string, params?: Twit.Params ): Promise<Twit.PromiseResponse>;
 
   // See https://github.com/ttezel/twit#tpostmediachunkedparams-callback
-  postMediaChunked( media: Twit.MediaParam, callback: Twit.Callback );
+  postMediaChunked( media: Twit.MediaParam, callback: Twit.Callback ): void;
 
   // See https://github.com/ttezel/twit#tgetauth
   getAuth(): Twit.Options
   // See https://github.com/ttezel/twit#tsetauthtokens
-  setAuth( tokens: Twit.ConfigKeys )
+  setAuth( tokens: Twit.ConfigKeys ): void;
 
   // See https://github.com/ttezel/twit#tstreampath-params
   stream( path: Twit.StreamEndpoint, params?: Twit.Params ): Readable;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "noImplicitAny": true
   },
   "files": [
     "../typings/main.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
+    "noImplicitAny": true,
     "outDir": "out"
   },
   "exclude": [


### PR DESCRIPTION
I found that the type definition occurs compilation errors because of implicit any.  So I explicitly added return type to some methods and enabled `noImplicitAny` by default to check them.
